### PR TITLE
Bug fix for Line 338 in mcfost/models.py

### DIFF
--- a/mcfost/models.py
+++ b/mcfost/models.py
@@ -335,7 +335,7 @@ class ModelResults(MCFOST_Dataset):
             ax = plt.subplot(121)
 
         # Display the image!
-        ax = utils.imshow_with_mouseover(ax, image,  norm=norm, cmap=cmap, extent=extent)
+        ax = utils.imshow_with_mouseover(ax, image,  norm=norm, cmap=cmap, extent=extent, origin='lower')
         ax.set_xlabel("Offset [{unit}]".format(unit=axes_units))
         ax.set_ylabel("Offset [{unit}]".format(unit=axes_units))
         ax.set_title("Image for "+wavelength+" $\mu$m")

--- a/mcfost/run.py
+++ b/mcfost/run.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import logging
 _log = logging.getLogger('mcfost')
+import numpy as np
 
 
 import astropy
@@ -70,6 +71,10 @@ def run_one_file(filename, wavelengths=[], move_to_subdir=True, delete_previous=
 
 
     run_sed(filename, delete_previous=delete_previous)
+    
+    if np.asarray(wavelengths).shape == ():
+        #when only one wavelength is given
+        wavelengths = [wavelengths]
 
     for wl in wavelengths:
         run_image(filename, wl, delete_previous=delete_previous)


### PR DESCRIPTION
Bug fix for Line 338 in mcfost/models.py, it showed an inverted image in Cell 26 in demo_mcfostpy.ipynb, now it is fine after adding `origin="lower"'. It was showing a non-inverted before, but it seems that the new matplotlib didn't take care of that.