### PR TITLE
Misc updates for MCFOST 3.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents
    observations.rst
    plots.rst
    chisqr.rst
+   testing.rst
 
 Indices and tables
 ------------------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,35 @@
+.. _testing:
+
+Automated Testing
+================================
+
+This package contains a few unit tests which can be used to verify basic functionality and correct operation. 
+The test suite is still in early development and is very incomplete for now. 
+
+
+These tests are designed to be run using the py.test framework. See http://docs.pytest.org
+
+To run, from the source code directory simply execute py.test::
+
+    unix> py.test
+    ======================== test session starts ==========================
+    platform darwin -- Python 2.7.11 -- py-1.4.20 -- pytest-2.5.2
+    plugins: cov
+    collected 3 items
+
+    mcfost/tests/test_paramfiles.py ...
+    ====================== 3 passed in 1.23 seconds =======================
+
+
+Descriptions of tests
+-----------------------
+
+Parameter files:
+
+ * Test reading in the MCFOST reference parameter files for versions 2.15, 2.20, and 3.0. 
+ * Test writing out the most recent parameter file (currently 3.0) and verifying that we can 
+   read back in the output file with the expected values. 
+ * Test the Parafile object attributes which are implemented via function calls as Python properties
+
+
+There is not yet any automated testing for other parts of the code. 

--- a/mcfost/chisqr.py
+++ b/mcfost/chisqr.py
@@ -56,7 +56,6 @@ def sed_chisqr(modelresults, observations, dof=1,
 #        raise ValueError("Second argument to sed_chisqr must be an Observations object")
     my_dof = dof
     if vary_distance:
-        #raise NotImplementedError("Varying distance not yet implemented")
         my_dof += 1
     if vary_AV:
         #_log.info("Computing chi^2 while allowing A_V to vary between {0} and {1} with R_V={2}".format(AV_range[0], AV_range[1], RV) )
@@ -64,7 +63,7 @@ def sed_chisqr(modelresults, observations, dof=1,
 
         import specutils
 
-    
+
     # observed wavelengths and fluxes 
     obs_wavelengths = observations.sed.wavelength
     obs_nufnu = observations.sed.nu_fnu
@@ -101,8 +100,6 @@ def sed_chisqr(modelresults, observations, dof=1,
             chi2 = ((obs_nufnu.value - est_mod_nufnu)**2 / obs_nufnu_uncert.value**2).sum()
 
         _log.info( "inclination {0} : {1:4.1f} deg has chi2 = {2:5g}".format(i, mod_inclinations[i], chi2))
-        #print "obs = ", obs_nufnu.value
-        #print "mod = ", est_mod_nufnu
 
 
         chi2s[i] = chi2
@@ -239,12 +236,9 @@ def fit_dist_extinct(wavelength, observed_sed_nuFnu, model,
 
     for i_r in np.arange(len(a_rv)):
         ext = np.asarray(utils.ccm_extinction(a_rv[i_r],wave_mu)) # Use wavelength in Angstroms
-        #print 'ext',wave_ang,ext
-        #ext[:]=0
         for i_d in np.arange(len(a_distance)):
             
             for i_a in np.arange(len(a_av)):
-                #print 'r',i_r,'d',i_d,'a',i_a,a_distance[i_d]
                 extinction = 10.0**((ext*a_av[i_a])/(-2.5))
                 vout = (np.multiply(model_sed_1pc,extinction))/(a_distance[i_d])**2 
                 
@@ -255,11 +249,9 @@ def fit_dist_extinct(wavelength, observed_sed_nuFnu, model,
                 else:   
                     chicomb = (vout-observed_sed_nuFnu)**2/(err_obs**2 + (vout*model_noise_frac)**2)
 
-                #print dof-additional_free
                 chisqs[i_d, i_a, i_r] = np.asarray(chicomb).sum()/7#(dof-additional_free-6) #Normalize to Reduced chi square.
     
     wmin = np.where(chisqs == np.nanmin(chisqs))
-    #print 'wmin',wmin
     sed_chisqr = np.nanmin(chisqs)
     best_distance = a_distance[wmin[0]]
     best_av = a_av[wmin[1]]

--- a/mcfost/models.py
+++ b/mcfost/models.py
@@ -72,7 +72,7 @@ class ModelImageCollection(collections.Mapping):
             try:
                 self.loaded_fits[canonical_wavelength].close()
             except:
-                print "Failed to close model image files."
+                print( "Failed to close model image files.")
 
 
     def __len__(self):
@@ -171,7 +171,6 @@ class ModelResults(MCFOST_Dataset):
             warnings.warn("No model image results were found in that directory.")
         self._wavelengths_lookup = {}
         for wl in image_waves:
-            #print wl
             wlstring = os.path.basename(wl).split('_')[1]
             self._wavelengths_lookup[float(wlstring)] = wlstring
 
@@ -525,7 +524,6 @@ class Observations(MCFOST_Dataset):
         for i, line in enumerate(summary):
             # filename, type, wavelength (optional)
             parts = line.split()
-            #print i, parts
             _log.info("Found observations: {0} is {1}".format(parts[0], " at ".join(parts[1:])) )
             thisfile = os.path.join(self.directory, parts[0])
             filenames.append(thisfile)

--- a/mcfost/paramfiles.py
+++ b/mcfost/paramfiles.py
@@ -2,7 +2,9 @@ import os
 import numpy as np
 import logging
 import glob
+import sys
 import astropy, astropy.io.ascii
+_PY2 = sys.version_info[0] == 2
 _log = logging.getLogger('mcfost')
 
 
@@ -132,11 +134,14 @@ class Paramfile(object):
             for item in somedict.items():
                 deftype =  type(item[1])
                 # force longer string field because the default behavior chops it to 1 character?!?
-                if deftype == str: deftype='S80'
+                # note we need to be more careful about S vs U if on Python 3
+                if deftype == str:
+                        deftype='S80' if _PY2 else 'U80'
                 dt.append( (item[0], deftype) )
 
                 vals.append(item[1])
             mydtype = np.dtype(dt)
+            print( tuple(vals), mydtype)
             return np.rec.array(tuple(vals),  dtype=mydtype)
 
 
@@ -520,7 +525,6 @@ class Paramfile(object):
         # see http://mail.scipy.org/pipermail/numpy-discussion/2013-June/066796.html
         def recarray2dict(somerecarray):
             mydict = {}
-            #print somerecarray.dtype.names
             for name, typecode in somerecarray.dtype.descr:
                 cast = float if 'f' in typecode else str
                 mydict[name] = cast(somerecarray[name])

--- a/mcfost/paramfiles.py
+++ b/mcfost/paramfiles.py
@@ -141,7 +141,6 @@ class Paramfile(object):
 
                 vals.append(item[1])
             mydtype = np.dtype(dt)
-            print( tuple(vals), mydtype)
             return np.rec.array(tuple(vals),  dtype=mydtype)
 
 

--- a/mcfost/paramfiles.py
+++ b/mcfost/paramfiles.py
@@ -5,15 +5,6 @@ import glob
 import astropy, astropy.io.ascii
 _log = logging.getLogger('mcfost')
 
-# this lets you put "stop()" in your code to have a debugger breakpoint
-# Old versions of ipython didn't seems to have IPython.core.debugger
-try:
-  from IPython.core.debugger import Tracer; stop = Tracer()
-except ImportError:
-  pass
-
-# some extremely simple classes to serve as structs.
-
 
 class Paramfile(object):
     """ Object class interface to MCFOST parameter files
@@ -108,6 +99,7 @@ class Paramfile(object):
 
 
         text = open(self.filename,'r').readlines()
+        lineptr = 3
 
         #--- First we define a variety of utility functions to be used below --
         # utility functions for pulling out specific items from a line
@@ -148,6 +140,15 @@ class Paramfile(object):
             return np.rec.array(tuple(vals),  dtype=mydtype)
 
 
+        def skip_blank_and_comment_lines(lineptr):
+            """ Skip past one or more blank lines and section
+            comment lines that start with'"#'"""
+            while ((text[lineptr].strip() == "") or
+                   (text[lineptr].strip().startswith("#"))):
+                reason = "blank" if text[lineptr].strip() == "" else "comment"
+                if verbose: _log.info("Skipping {} line : {}".format(reason, lineptr+1))
+                lineptr+=1
+            return lineptr
 
         self.fulltext = text
 
@@ -158,16 +159,16 @@ class Paramfile(object):
         if self.version < self._minimum_version: raise Exception('Parameter file version must be at least {ver:.2f}'.format(ver=self._minimum_version))
 
         #-- Number of photon packages --
-        lineptr = 3
         if (float(self.version) < 2.15):
             set1part( 'nbr_parallel_loop', lineptr, 1, int) ; lineptr+=1
         else:
             self.nbr_parallel_loop = 1
         set1part('nbr_photons_eq_th', lineptr, 1, float) ; lineptr+=1
         set1part('nbr_photons_lambda',lineptr, 1, float) ; lineptr+=1
-        set1part('nbr_photons_image', lineptr, 1, float) ; lineptr+=3
+        set1part('nbr_photons_image', lineptr, 1, float) ; lineptr+=1
 
         #--  Wavelength --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('nwavelengths', lineptr, 1, int)
         set1part('lambda_min', lineptr, 2, float)
         set1part('lambda_max', lineptr, 3, float) ; lineptr+=1
@@ -176,24 +177,27 @@ class Paramfile(object):
         set1part('l_complete', lineptr, 3, bool) ; lineptr+=1
         set1part('wavelengths_file', lineptr, 1, str) ; lineptr+=1
         set1part('l_separate', lineptr, 1, bool)
-        set1part('l_stokes', lineptr, 2, bool)  ; lineptr+=3
-
+        set1part('l_stokes', lineptr, 2, bool)  ; lineptr+=1
 
         #-- Grid geometry and size --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('grid_type', lineptr, 1, int) ; lineptr+=1
         set1part('grid_n_rad', lineptr, 1, int)
         set1part('grid_nz', lineptr, 2, int) # should be n_theta if type=spherical
         set1part('grid_n_az', lineptr, 3, int)
-        set1part('grid_n_rad_in', lineptr, 4, int) ; lineptr+=3
+        set1part('grid_n_rad_in', lineptr, 4, int) ; lineptr+=1
 
         #--  Maps (Images) --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('im_nx',lineptr , 1 if float(self.version) >= 2.15 else 3, int),
         set1part('im_ny',lineptr , 2 if float(self.version) >= 2.15 else 4, int),
         if float(self.version) >= 2.15:
             set1part('im_map_size', lineptr , 3, float)
         lineptr+=1
-        set1part('MC_n_incl',lineptr , 1, int if self.version >= 2.17 else float),
-        set1part('MC_n_az',lineptr , 2, int) ; lineptr+=1
+        if float(self.version) < 3.0:
+            set1part('MC_n_incl',lineptr , 1, int if self.version >= 2.17 else float),
+            set1part('MC_n_az',lineptr , 2, int)
+            lineptr+=1
         set1part('RT_imin', lineptr, 1, float)
         set1part('RT_imax', lineptr, 2, float)
         set1part('RT_n_incl',lineptr , 3, int)
@@ -209,6 +213,7 @@ class Paramfile(object):
             self.disk_pa = 0
         lineptr+=2
 
+        lineptr = skip_blank_and_comment_lines(lineptr)
 
         # compute inclinations used for SED
         # FIXME this needs updating for SED RT mode
@@ -237,15 +242,19 @@ class Paramfile(object):
 
 
         #-- Scattering Method --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('scattering_method', lineptr, 1, int) ; lineptr+=1
-        set1part('scattering_mie_hg', lineptr, 1, int) ; lineptr+=3
+        set1part('scattering_mie_hg', lineptr, 1, int) ; lineptr+=1
 
         #-- Symmetries --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('l_image_symmetry', lineptr, 1, bool) ; lineptr+=1
         set1part('l_central_symmetry', lineptr, 1, bool) ; lineptr+=1
-        set1part('l_axial_symmetry', lineptr, 1, bool) ; lineptr+=3
+        set1part('l_axial_symmetry', lineptr, 1, bool) ; lineptr+=1
+        lineptr = skip_blank_and_comment_lines(lineptr)
 
         #-- Disk physics / dust global properties --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         if float(self.version) >2.15:
             set1part('dust_settling', lineptr, 1, int)
         else:
@@ -266,16 +275,17 @@ class Paramfile(object):
             self.l_hydrostatic_equilibrium = False
         set1part('l_viscous_heating' ,lineptr, 1, bool)
         set1part('alpha_viscosity' ,lineptr, 2, float) ; lineptr+=1
-        lineptr+=2
 
 
         #-- Number of Zones --
         # read in the different zones
-        set1part( 'nzones' ,lineptr, 1,int) ; lineptr+=3
+        lineptr = skip_blank_and_comment_lines(lineptr)
+        set1part( 'nzones' ,lineptr, 1,int) ; lineptr+=1
 
         #-- Density Structure (1 per zone) --
         self.density_zones=[]
         for idensity in range(self.nzones):
+            lineptr = skip_blank_and_comment_lines(lineptr)
             density={}
             set1partOfDict(density, 'zone_type', lineptr, 1, int) ; lineptr+=1
             set1partOfDict(density, 'dust_mass', lineptr, 1, float)
@@ -307,38 +317,41 @@ class Paramfile(object):
                 set1partOfDict(density, 'gamma_exp', lineptr, 2, float)
             else:
                 density['gamma_exp'] = 0.0
-            lineptr+=2
+            lineptr+=1
 
             self.density_zones.append(density)
-        lineptr+=1
-        #-- Cavity --
-        set1part('cavity_flag', lineptr, 1, str) ; lineptr+=1
-        set1part('cavity_height', lineptr, 1, float)
-        set1part('cavity_ref_radius', lineptr, 2, float) ; lineptr+=1
-        set1part('cavity_flaring_exp', lineptr, 1, float) ; lineptr+=3
+
+        if float(self.version) < 3.0:
+            lineptr = skip_blank_and_comment_lines(lineptr)
+            #-- Cavity --
+            set1part('cavity_flag', lineptr, 1, str) ; lineptr+=1
+            set1part('cavity_height', lineptr, 1, float)
+            set1part('cavity_ref_radius', lineptr, 2, float) ; lineptr+=1
+            set1part('cavity_flaring_exp', lineptr, 1, float) ; lineptr+=3
 
 
         #-- Grain properties --
         # read in the dust grain properties. One set of dust props **per zone**, each of which can contain multiple species
         # These are each stored as a list of dicts per each zone.
         for idensity in range(self.nzones):
+            lineptr = skip_blank_and_comment_lines(lineptr)
             #self.density_zones['dust_nspecies']=[]
             set1partOfDict(self.density_zones[idensity], 'dust_nspecies', lineptr, 1,int)
             lineptr+=1
             self.density_zones[idensity]['dust']=[]
             for idust in range(self.density_zones[idensity]['dust_nspecies']):
+                lineptr = skip_blank_and_comment_lines(lineptr)
                 dust={}
                 if float(self.version) >= 2.12:
                     # version 2.12 or higher, allow for multi-component grains
                     if self.version >= 2.17:
-                        set1partOfDict(self.density_zones[idensity],'grain_type', lineptr, 1, str)
+                        set1partOfDict(dust,'grain_type', lineptr, 1, str)
 
                     set1partOfDict(dust, 'ncomponents',  lineptr, 2 if self.version >=2.17 else 1, int),
                     set1partOfDict(dust, 'mixing_rule',  lineptr, 3 if self.version >=2.17 else 2, int),
                     set1partOfDict(dust, 'porosity',     lineptr, 4 if self.version >=2.17 else 3, float),
                     set1partOfDict(dust, 'mass_fraction',lineptr, 5 if self.version >=2.17 else 4, float)
                     lineptr+=1
-                    #if dust['ncomponents'] >1: raise NotImplementedError("Need multi-component parsing code!")
                     components=[]
                     for icomponent in range(dust['ncomponents']):
                         this_component={}
@@ -358,7 +371,7 @@ class Paramfile(object):
                             ('ngrains', lineptr+1, 4, int))
                     for key, line, item, typ in dust_keys:
                         set1partOfDict(dust,key, line, item, typ)
-                    lineptr+=3
+                    lineptr+=2
                     
 
                 else:
@@ -376,14 +389,14 @@ class Paramfile(object):
                     i+=3
                 #add any missing keywords using defaults. This is to handle
                 # parsing earlier versions of the parameter file that lacked some settings
-                defaults = (('volume_fraction',1.0), ('grain_type', 'Mie'))
-                for defkey, defval in defaults:
-                    if defkey not in dust.keys() : dust[defkey] = defval
+                #defaults = (('volume_fraction',1), ('grain_type', 'Mie'))
+                #for defkey, defval in defaults:
+                    #if defkey not in dust.keys() : dust[defkey] = defval
 
                 self.density_zones[idensity]['dust'].append(dust)
-        lineptr+=1
 
         # molecular RT settings
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('l_pop', lineptr, 1, bool)
         set1part('l_accurate_pop', lineptr, 2, bool)
         set1part('l_LTE', lineptr, 3, bool)
@@ -401,9 +414,8 @@ class Paramfile(object):
         set1part('molecular_raytrace_n_lines', lineptr, 2, float); lineptr+=1
         lineptr+=1 # skip transition numbers for now
 
-        lineptr+=2
-
         #-- Star properties --
+        lineptr = skip_blank_and_comment_lines(lineptr)
         set1part('nstar', lineptr, 1,int) ; lineptr +=1
         self.stars = []
         for istar in range(self.nstar):
@@ -489,6 +501,7 @@ class Paramfile(object):
         2013-04-24 Substantial code rewrites & cleanup. Updated to version 2.17
         2014-01-12 Updated to version 2.19
         2015-06-15 Updated to version 2.20
+        2016-08-15 Updates to version 3.0
 
         """
         #par = self._dict
@@ -518,7 +531,7 @@ class Paramfile(object):
             return "T" if somebool else "F"
 
 
-        template = """2.20                      mcfost version
+        template = """3.0                       mcfost version
 
 #Number of photon packages
   {self.nbr_photons_eq_th:<10.5g}              nbr_photons_eq_th  : T computation
@@ -537,7 +550,6 @@ class Paramfile(object):
 
 #Maps
   {self.im_nx:<3d} {self.im_ny:3d} {self.im_map_size:5.1f}        grid (nx,ny), size [AU]
-  {self.MC_n_incl} {self.MC_n_az}               MC : N_bin_incl, N_bin_az
   {self.RT_imin:<4.1f}  {self.RT_imax:<4.1f}  {self.RT_n_incl:>2d} {str_RT_centered}    RT: imin, imax, n_incl, centered ?
   {self.RT_az_min:<4.1f}  {self.RT_az_max:<4.1f}  {self.RT_n_az:>2d}    RT: az_min, az_max, n_az
   {self.distance:<6.2f}                 distance (pc)
@@ -598,7 +610,8 @@ class Paramfile(object):
   {zone[surface_density_exp]:<6.3f} {zone[gamma_exp]:<6.3f}                surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
         """.format(zone = self.density_zones[zone])
 
-        template+="""
+        if float(self.version) < 3.0:
+           template+="""
 #Cavity : everything is empty above the surface
   {self.cavity_flag}                        cavity ?
   {self.cavity_height:<5.1f}  {self.cavity_ref_radius:<5.1f}             height, reference radius (AU)

--- a/mcfost/paramfiles.py
+++ b/mcfost/paramfiles.py
@@ -41,7 +41,7 @@ class Paramfile(object):
     def wavelengths(self):
         """ Wavelengths in microns for SED, as specified in the parameter file """
         # compute or look up wavelength solution
-        if self.l_complete:
+        if self.l_sed_complete:
             # use log sampled wavelength range
             wavelengths_inc=np.exp( np.log(self.lambda_max/self.lambda_min)/(self.nwavelengths) )
             return self.lambda_min * wavelengths_inc**(np.arange(self.nwavelengths)+0.5)
@@ -174,7 +174,7 @@ class Paramfile(object):
         set1part('lambda_max', lineptr, 3, float) ; lineptr+=1
         set1part('l_temp', lineptr, 1, bool) # should be bool type?
         set1part('l_sed',  lineptr, 2, bool)
-        set1part('l_complete', lineptr, 3, bool) ; lineptr+=1
+        set1part('l_sed_complete', lineptr, 3, bool) ; lineptr+=1
         set1part('wavelengths_file', lineptr, 1, str) ; lineptr+=1
         set1part('l_separate', lineptr, 1, bool)
         set1part('l_stokes', lineptr, 2, bool)  ; lineptr+=1
@@ -540,7 +540,7 @@ class Paramfile(object):
 
 #Wavelength
   {self.nwavelengths:<3d} {self.lambda_min:<5.1f} {self.lambda_max:<7g}       n_lambda, lambda_min, lambda_max [microns]
-  {str_l_temp:1s} {str_l_sed:1s} {str_l_complete:1s}                   compute temperature?, compute sed?, use default wavelength grid ?
+  {str_l_temp:1s} {str_l_sed:1s} {str_l_sed_complete:1s}                   compute temperature?, compute sed?, use default wavelength grid ?
   {self.wavelengths_file}           wavelength file (if previous parameter is F)
   {str_l_separate:1s} {str_l_stokes:1s}                     separation of different contributions?, stokes parameters?
 
@@ -557,7 +557,7 @@ class Paramfile(object):
   """.format(self=self,
           str_l_temp=bstr(self.l_temp), # is there a better way to get a Bool to print as a single letter?
           str_l_sed=bstr(self.l_sed),
-          str_l_complete=bstr(self.l_complete),
+          str_l_sed_complete=bstr(self.l_sed_complete),
           str_l_separate=bstr(self.l_separate),
           str_l_stokes=bstr(self.l_stokes),
           str_RT_centered=bstr(self.RT_centered),
@@ -638,15 +638,21 @@ class Paramfile(object):
 
         template+="""
 #Molecular RT settings
-  T T T 15.              lpop, laccurate_pop, LTE, profile width
-  0.2                    v_turb (delta)
-  1                      nmol
-  co@xpol.dat 6          molecular data filename, level_max
-  1.0 50                 vmax (km.s-1), n_speed
-  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
-  T  3                   ray tracing ?,  number of lines in ray-tracing
+  {str_lpop}  {str_lacpop}  {str_lte} {self.molecular_profile_width:f}              lpop, laccurate_pop, LTE, profile width
+  {self.molecular_v_turb}                    v_turb (delta)
+  {self.molecular_nmol}                      nmol
+  {self.molecular_filename} {self.molecular_level_max}          molecular data filename, level_max
+  {self.molecular_vmax} {self.molecular_n_speed}                 vmax (km.s-1), n_speed
+  {str_molab} {self.molecular_abundance} {self.molecular_abundance_file}   cst molecule abundance ?, abundance, abundance file
+  {str_molray}  {self.molecular_raytrace_n_lines}                   ray tracing ?,  number of lines in ray-tracing
   1 2 3                  transition numbers
-      """
+      """.format(self=self,
+              str_lpop = bstr(self.l_pop),
+              str_lacpop =bstr(self.l_accurate_pop),
+              str_lte = bstr(self.l_LTE),
+              str_molab = bstr(self.l_molecular_abundance),
+              str_molray=bstr(self.l_molecular_raytrace))
+
 
         template+="""
 #Star properties

--- a/mcfost/plotting.py
+++ b/mcfost/plotting.py
@@ -303,14 +303,25 @@ def plot_dust(directory='./', noerase=False, parameters=None):
     if os.path.exists(os.path.join(directory, "polar.fits.gz")):
         has_polar= True
         polar = fits.getdata(os.path.join(directory, "polar.fits.gz"))
+    elif os.path.exists(os.path.join(directory, "polarizability.fits.gz")):
+        has_polar= True
+        polar = fits.getdata(os.path.join(directory, "polarizability.fits.gz"))
     else:
         has_polar = False
+
+    if os.path.exists(os.path.join(directory, "phase_function.fits.gz")):
+        has_phase= True
+        phase = fits.getdata(os.path.join(directory, "phase_function.fits.gz"))
+    else:
+        has_phase = False
+
+
 
     if noerase is False:  plt.clf()
     plt.subplots_adjust(top=0.98, hspace=0.3, wspace=0.4)
     ax = plt.subplot(321)
     plt.semilogx(lambd, kappa)
-    plt.ylabel("Opacity $\kappa$")
+    plt.ylabel("Opacity $\kappa$ [cm$^2$/g]")
     ax.yaxis.set_major_locator( matplotlib.ticker.MaxNLocator(5) )
 
     #----
@@ -328,29 +339,51 @@ def plot_dust(directory='./', noerase=False, parameters=None):
     ax.yaxis.set_major_locator( matplotlib.ticker.MaxNLocator(5) )
     #ax.set_yticks([0.0, 0.25, 0.5, 0.75, 1.0])
 
+    #----- now switch to show the phase function versus angle ----
 
-    #----- now switch to show the polarization versus angle ----
-
-    ax = plt.subplot(122)
-    # move this 4th plot down slightly for visual offset
-    pos = ax.get_position()
-    pa = pos.get_points()
-    pa[0,1] *= 0.5
-    pos.set_points(pa)
-    ax.set_position(pos)
-
-    polwaves = np.asarray([1.0, 2.5, 10.0, 100.0])
+    # these variables are used for both phase function and polarization
+    pwaves = np.asarray([1.0, 2.5, 10.0, 100.0])
+    colors = ['blue', 'green', 'orange', 'red']
     theta = np.r_[0:180]
+
+
+    ax = plt.subplot(222)
     plt.xlabel("Scattering Angle [degrees]")
-    plt.ylabel("Polarization $[-S_{12}/S_{11}]$")
-    plt.axis(xmin=0,xmax=180, ymin=0,ymax=1)
+    plt.ylabel("Phase Function")
     plt.xticks(np.arange(7)*30)
-    if has_polar:
-        for i in np.arange(polwaves.size):
-           c = utils.find_closest(lambd, polwaves[i])
-           plt.plot(polar[:,c].ravel(), label=str(polwaves[i])+" $\mu$m" )
+
+    if has_phase:
+        for i in np.arange(pwaves.size):
+           c = utils.find_closest(lambd, pwaves[i])
+           plt.semilogy(phase[:,c].ravel(), label=str(pwaves[i])+" $\mu$m", color=colors[i] )
 
         prop = matplotlib.font_manager.FontProperties(size=10)
         plt.legend(prop=prop)
     else:
-        plt.text(90,0.5, 'Polarization information\n not enabled', horizontalalignment='center', verticalalignment='center')
+        plt.text(90,0.5, 'Phase function information\n not present', horizontalalignment='center', verticalalignment='center')
+    #----- now switch to show the polarization versus angle ----
+
+    ax = plt.subplot(224)
+    # move this 4th plot down slightly for visual offset
+    #pos = ax.get_position()
+    #pa = pos.get_points()
+    #pa[0,1] *= 0.5
+    #pos.set_points(pa)
+    #ax.set_position(pos)
+
+    theta = np.r_[0:180]
+    plt.xlabel("Scattering Angle [degrees]")
+    plt.ylabel("Polarization $[-S_{12}/S_{11}]$")
+    ymin = -1 if polar.min() < 0 else 1
+
+    plt.axis(xmin=0,xmax=180, ymin=ymin,ymax=1)
+    plt.xticks(np.arange(7)*30)
+    if has_polar:
+        for i in np.arange(pwaves.size):
+           c = utils.find_closest(lambd, pwaves[i])
+           plt.plot(polar[:,c].ravel(), label=str(pwaves[i])+" $\mu$m" , color=colors[i])
+
+        prop = matplotlib.font_manager.FontProperties(size=10)
+        plt.legend(prop=prop)
+    else:
+        plt.text(90,0.5, 'Polarization information\n not present', horizontalalignment='center', verticalalignment='center')

--- a/mcfost/tests/__init__.py
+++ b/mcfost/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_paramfiles

--- a/mcfost/tests/ref2.15.para
+++ b/mcfost/tests/ref2.15.para
@@ -1,0 +1,76 @@
+2.15                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation 
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F F			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical	
+  100 70 1 20             n_rad, nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 3000.  1.0      grid (nx,ny), size [AU], zoom factor
+  10 1   1                MC : N_bin_incl, N_bin_az, # of bin where MC is converged 
+  45.  55.  11  F          RT: imin, imax, n_incl, centered ?      
+  140.0			  distance (pc)  
+  0.			  disk PA	
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry 
+  T	                  axial symmetry (important only if N_phi > 1)  
+
+#Dust global properties
+  F  0.00  1.0		  dust settling, exp_strat, a_strat
+  F		  	  sublimate dust
+  F  0.0		  viscous heating, viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  2                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope	
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio	
+  10.  100.0              scale height, reference radius (AU), unused for envelope
+  1.0  300.0 0.00         Rin, Rout (or Rc), edge (AU)
+  1.125                   flaring exponent, unused for envelope
+  -0.5      	          surface density exponent (or -gamma for tappered-edge disk), usually < 0
+
+#Cavity : everything is empty above the surface
+ F	  	     	  cavity ?    	
+ 15. 50.		  height, reference radius (AU)
+ 1.5 			  flaring exponent	  
+
+#Grain properties
+  1  Number of species
+  1  2  0.0  1.0   N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction 
+  Draine_Si_sUV.dat  0.8   optical indices file, volume fraction
+  1	  heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1.0 3.5 100 	  amin, amax, aexp, nbr_grains     
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width 
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max 
+  1.0 20     	  	  vmax (m.s-1), n_speed 
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file	  
+  T  3                       ray tracing ?,  number of lines in ray-tracing	
+  1 2 3	 		  transition numbers	
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV	

--- a/mcfost/tests/ref2.20.para
+++ b/mcfost/tests/ref2.20.para
@@ -1,0 +1,79 @@
+2.20                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid for ouput ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F T			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 700.           grid (nx,ny), size [AU]
+  10   1   1              MC : N_bin_incl, N_bin_az
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  0     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0    	          surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Cavity : everything is empty above the surface
+ F	  	     	  cavity ?
+ 15. 50.		  height, reference radius (AU)
+ 1.5 			  flaring exponent
+
+#Grain properties
+  1  Number of species
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/ref2.20_3D.para
+++ b/mcfost/tests/ref2.20_3D.para
@@ -1,0 +1,84 @@
+2.20                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F T			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 36 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 3000.           grid (nx,ny), size [AU]
+  10   1   1              MC : N_bin_incl, N_bin_az
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    240.   3           RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  3     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0    	          surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Cavity : everything is empty above the surface
+ F	  	     	  cavity ?
+ 15. 50.		  height, reference radius (AU)
+ 1.5 			  flaring exponent
+
+#Grain properties
+  2  Number of species
+  Mie  1 2  0.0  0.75  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.1  1000.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+Mie  1 2  0.0  0.25  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  amor_carbon.dat   1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.1  10.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/ref2.20_multi.para
+++ b/mcfost/tests/ref2.20_multi.para
@@ -1,0 +1,99 @@
+2.20                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum]  Do not change this line unless you know what you are doing
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F F			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 3000.           grid (nx,ny), size [AU]
+  10 1   1                MC : N_bin_incl, N_bin_az
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  1     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  2
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-8    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0   2          scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.  0.  5.0 5.0         Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5   -0.5   	  surface density exponent (or -gamma for tappered-edge disk), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  10.  0.    300.0 100.0  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  -0.5    	  surface density exponent (or -gamma for tappered-edge disk), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Cavity : everything is empty above the surface
+ F	  	     	  cavity ?
+ 15. 50.		  height, reference radius (AU)
+ 1.5 			  flaring exponent
+
+#Grain properties
+  1  Number of species
+  Mie   1 2    0.0  1.0   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 50 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+
+  2  Number of species
+  Mie   2 2    0.0  0.999   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  0.8  Optical indices file, volume fraction
+  ice_opct.dat  0.2  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 50 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+  Mie   1 2    0.0  1.e-3   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  PAHneu.dat  1.0  Optical indices file, volume fraction
+  3	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  5e-4  5e-4 3.5 1 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/ref3.0.para
+++ b/mcfost/tests/ref3.0.para
@@ -1,0 +1,73 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T F 		  compute temperature?, compute sed?, use default wavelength grid for ouput ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F T			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 700.            grid (nx,ny), size [AU]
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  0     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0    	          surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  1  Number of species
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/ref3.0_3D.para
+++ b/mcfost/tests/ref3.0_3D.para
@@ -1,0 +1,78 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F T			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 50 100 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 3000.           grid (nx,ny), size [AU]
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    240.   3           RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  3     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-3		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0    	          surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  2  Number of species
+  Mie  1 2  0.0  0.75  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  2	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.1  1000.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+Mie  1 2  0.0  0.25  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  amor_carbon.dat   1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.1  10.0 3.5 100 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/ref3.0_multi.para
+++ b/mcfost/tests/ref3.0_multi.para
@@ -1,0 +1,93 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3	          nbr_photons_lambda : SED computation
+  1.28e5                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum]  Do not change this line unless you know what you are doing
+  T T T 		  compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda		  wavelength file (if previous parameter is F)
+  F F			  separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1			  1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 3000.           grid (nx,ny), size [AU]
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0			  distance (pc)
+  0.			  disk PA
+
+#Scattering method
+  0	                  0=auto, 1=grain prop, 2=cell prop
+  1	                  1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T	                  image symmetry
+  T	                  central symmetry
+  T	                  axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  1     0.50  1.0	  dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F		  	  sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5		  viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  2
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-8    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0   2          scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.  0.  5.0 5.0         Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5   -0.5   	  surface density exponent (or -gamma for tappered-edge disk), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = wall
+  1.e-3    100.		  dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  10.  0.    300.0 100.0  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  -0.5    	  surface density exponent (or -gamma for tappered-edge disk), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  1  Number of species
+  Mie   1 2    0.0  1.0   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 50 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+
+  2  Number of species
+  Mie   2 2    0.0  0.999   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  0.8  Optical indices file, volume fraction
+  ice_opct.dat  0.2  Optical indices file, volume fraction
+  1	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 50 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+  Mie   1 2    0.0  1.e-3   0.9  Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  PAHneu.dat  1.0  Optical indices file, volume fraction
+  3	                  Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  5e-4  5e-4 3.5 1 	  amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.	          lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2 			  v_turb (delta)
+  1			  nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20     	  	  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                       ray tracing ?,  number of lines in ray-tracing
+  1 2 3	 		  transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0	2.0	1.0	0.0	0.0	0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.1	2.2  fUV, slope_fUV

--- a/mcfost/tests/test_paramfiles.py
+++ b/mcfost/tests/test_paramfiles.py
@@ -54,17 +54,30 @@ def test_write_par_file(delete=False):
     # and see if we can read it back in
     pf2 = mcfost.Paramfile(outname)
 
-def test_properties():
+    # and see if the values in the output file match those in the original file.
+    for key in pf2.__dict__.keys():
+        # some particular keys we don't expect to round trip exactly identically:
+        if key in ['filename', 'fulltext']:
+            continue
+        # but all the others should:
+        assert pf[key] == pf2[key], "Did not round-trip the value for {}: {} vs {}".format(key, pf[key], pf2[key])
+
+
+def test_properties(filename=None):
     """ Test the parameter file virtual attributes which are
     implemented via function calls via @properties
     """
-    filename = os.path.join(os.path.dirname(__file__), 'ref{}.para'.format(LATEST_VER))
+    if filename is None:
+        filename = os.path.join(os.path.dirname(__file__), 'ref{}.para'.format(LATEST_VER))
     pf = mcfost.Paramfile(filename)
 
 
     wavelens = pf.wavelengths
     assert isinstance(wavelens, np.ndarray)
-    assert wavelens.size == pf.nwavelengths
+    if pf.l_sed_complete:
+        # we should only do this test if we're using default wavelengths
+        # and not reading the wvelengths from an input FITS file.
+        assert wavelens.size == pf.nwavelengths
 
 
     # test the abbreviations:

--- a/mcfost/tests/test_paramfiles.py
+++ b/mcfost/tests/test_paramfiles.py
@@ -1,0 +1,73 @@
+import mcfost
+
+import os
+import glob
+import numpy as np
+
+TEST_DATA_PATH = '/Users/mperrin/Dropbox (Personal)/Documents/software/mcfost'
+
+LATEST_VER = '3.0'
+
+def do_test_read_one_par_file(filename, verbose=True):
+    """
+    Test the reading of parameter files.
+
+    This relies on a copy of the 'refX.XX.para' reference example parameter
+    files being present in this directory. This is not automatically updated,
+    so right now somebody needs to manually update this whenever the MCFOST
+    version number changes.
+    """
+
+
+    #check that we can read the file in
+    pf = mcfost.Paramfile(filename, verbose=verbose)
+
+    #check at least one attribute, from near the end of the file. 
+    # if we've read this in correctly then it's at least plausible the whole
+    # file is read OK. 
+    assert isinstance(pf.version,float)
+
+    assert pf.star.temp == 4000, "Did not get the expected stellar temperature from param file"
+
+    # try a couple other parameters just for kicks. 
+    assert pf.lambda_max == 3000, "Did not get the expected lambda_max from param file"
+    assert pf.distance == 140, "Did not get the expected distance from param file"
+    assert pf.l_pop == True, "Did not get the expected l_pop from param file"
+
+
+def test_read_all_par_files():
+    filenames = glob.glob(os.path.join(os.path.dirname(__file__), 'ref*.para'))
+    for fn in filenames:
+        do_test_read_one_par_file(fn)
+
+
+def test_write_par_file(delete=False):
+    import tempfile
+    tmp = tempfile.NamedTemporaryFile(delete=delete)
+    outname = tmp.name
+
+    filename = os.path.join(os.path.dirname(__file__), 'ref{}.para'.format(LATEST_VER))
+    pf = mcfost.Paramfile(filename)
+
+    #write it out
+    pf.writeto(outname)
+    # and see if we can read it back in
+    pf2 = mcfost.Paramfile(outname)
+
+def test_properties():
+    """ Test the parameter file virtual attributes which are
+    implemented via function calls via @properties
+    """
+    filename = os.path.join(os.path.dirname(__file__), 'ref{}.para'.format(LATEST_VER))
+    pf = mcfost.Paramfile(filename)
+
+
+    wavelens = pf.wavelengths
+    assert isinstance(wavelens, np.ndarray)
+    assert wavelens.size == pf.nwavelengths
+
+
+    # test the abbreviations:
+    assert pf.star is pf.stars[0]
+    assert pf.density is pf.density_zones[0]
+    assert pf.dust is pf.density_zones[0]['dust'][0]


### PR DESCRIPTION
I've updated the parameter file reading and writing code to handle version 3.0, and updated the dust properties plotting function.  I've also started some unit testing infrastructure to ensure correctness, such as by testing that it can successfully read both older and current the reference parameter files, specifically those from 2.15, 2.20, and 3.0. See docs/testing.rst for more info on this if you're not familiar with `py.test` yet.  Lastly I made a few minor fixes to get the tests passing on Python 3.4 as well as 2.7. 